### PR TITLE
Fix console stream blocking when buffer fills

### DIFF
--- a/src/subsystems/console.rs
+++ b/src/subsystems/console.rs
@@ -77,10 +77,14 @@ impl Console {
     pub(crate) async fn new(
         downlink: channel::Receiver<Packet>,
     ) -> Result<Self> {
-        let (stream_broadcast, stream_broadcast_receiver) = broadcast(1000);
+        let (mut stream_broadcast, stream_broadcast_receiver) = broadcast(1000);
         let console_buffer: Arc<Mutex<String>> = Default::default();
 
-        let (line_broadcast, line_broadcast_receiver) = broadcast(1000);
+        let (mut line_broadcast, line_broadcast_receiver) = broadcast(1000);
+
+        // Enable overflow mode so old messages are dropped instead of blocking
+        stream_broadcast.set_overflow(true);
+        line_broadcast.set_overflow(true);
         let console_lines: Arc<Mutex<Vec<String>>> = Default::default();
 
         let buffer = console_buffer.clone();


### PR DESCRIPTION
Enable overflow mode on console broadcast channels to prevent the background task from blocking when consumers can't keep up with incoming console data. Without overflow mode, slow readers would cause the broadcast to block after 1000 messages, freezing all console output.

Tested by running the hello world STM32 app in a high frequency loop