### PR TITLE
Increase read/write size per message for memory access

### DIFF
--- a/src/subsystems/memory/memory_types.rs
+++ b/src/subsystems/memory/memory_types.rs
@@ -8,7 +8,7 @@ use crate::crazyflie::MEMORY_PORT;
 const READ_CHANNEL: u8 = 1;
 const WRITE_CHANNEL: u8 = 2;
 
-const MEM_MAX_REQUEST_SIZE: usize = 20;
+const MEM_MAX_REQUEST_SIZE: usize = 24;
 
 
 /// Description of a memory in the Crazyflie


### PR DESCRIPTION
Currently we're only using 20 bytes per message when accessing memories, increase this to 24 bytes.

[Documentation for the CRTP memory subsystem.](https://www.bitcraze.io/documentation/repository/crazyflie-firmware/master/functional-areas/crtp/crtp_mem/)