### PR TITLE
Improve TocCache trait design and simplify synchronization

### DIFF
--- a/examples/test_toc_cache.rs
+++ b/examples/test_toc_cache.rs
@@ -2,29 +2,29 @@
 /// and measuring connection times with and without TOC caching.
 use crazyflie_lib::{Crazyflie, TocCache};
 use crazyflie_link::LinkContext;
-use std::{collections::HashMap, sync::Arc, sync::Mutex};
+use std::{collections::HashMap, sync::Arc, sync::RwLock};
 use tokio::time::{sleep, Duration};
 
 #[derive(Clone)]
 struct InMemoryTocCache {
-  toc: Arc<Mutex<HashMap<u32, String>>>,
+  toc: Arc<RwLock<HashMap<u32, String>>>,
 }
 
 impl InMemoryTocCache {
   fn new() -> Self {
     InMemoryTocCache {
-      toc: Arc::new(Mutex::new(HashMap::new())),
+      toc: Arc::new(RwLock::new(HashMap::new())),
     }
   }
 }
 
 impl TocCache for InMemoryTocCache {
   fn get_toc(&self, crc32: u32) -> Option<String> {
-    self.toc.lock().ok()?.get(&crc32).cloned()
+    self.toc.read().ok()?.get(&crc32).cloned()
   }
 
-  fn store_toc(&mut self, crc32: u32, toc: &str) {
-    if let Ok(mut lock) = self.toc.lock() {
+  fn store_toc(&self, crc32: u32, toc: &str) {
+    if let Ok(mut lock) = self.toc.write() {
       lock.insert(crc32, toc.to_string());
     }
   }

--- a/src/crazyflie.rs
+++ b/src/crazyflie.rs
@@ -146,9 +146,6 @@ impl Crazyflie {
             return Err(Error::ProtocolVersionNotSupported);
         }
 
-        // Create the TOC cache
-        let toc_cache = Arc::new(Mutex::new(toc_cache));
-
         // Create subsystems one by one
         // The future is passed to join!() later down so that all modules initializes at the same time
         // The get_port_receiver calls are guaranteed to work if the same port is not used twice (any way to express that at compile time?)

--- a/src/crtp_utils.rs
+++ b/src/crtp_utils.rs
@@ -8,7 +8,6 @@ use async_trait::async_trait;
 use crazyflie_link::Packet;
 use flume as channel;
 use flume::{Receiver, Sender};
-use futures::lock::Mutex;
 use serde::{Deserialize, Serialize};
 use tokio::task::JoinHandle;
 use std::collections::BTreeMap;
@@ -106,10 +105,10 @@ pub(crate) async fn fetch_toc<C, T, E>(
     port: u8,
     uplink: channel::Sender<Packet>,
     downlink: channel::Receiver<Packet>,
-    toc_cache: Arc<Mutex<C>>,
+    toc_cache: C,
 ) -> Result<std::collections::BTreeMap<String, (u16, T)>>
 where
-    C: TocCache + Send + Sync + 'static,
+    C: TocCache,
     T: TryFrom<u8, Error = E> + Serialize + for<'de> Deserialize<'de>,
     E: Into<Error>,
 {
@@ -126,11 +125,13 @@ where
 
     let mut toc = std::collections::BTreeMap::new();
 
-    if let Some(toc_str) = toc_cache.lock().await.get_toc(toc_crc32) {
+    // Check cache first
+    if let Some(toc_str) = toc_cache.get_toc(toc_crc32) {
         toc = serde_json::from_str(&toc_str).map_err(|e| Error::InvalidParameter(format!("Failed to deserialize TOC cache: {}", e)))?;
         return Ok(toc);
     }
 
+    // Fetch TOC from device
     for i in 0..toc_len {
         let pk = Packet::new(
             port,
@@ -153,8 +154,9 @@ where
         toc.insert(format!("{}.{}", group, name), (id, item_type));
     }
 
+    // Store in cache
     let toc_str = serde_json::to_string(&toc).map_err(|e| Error::InvalidParameter(format!("Failed to serialize TOC: {}", e)))?;
-    toc_cache.lock().await.store_toc(toc_crc32, &toc_str);
+    toc_cache.store_toc(toc_crc32, &toc_str);
 
     Ok(toc)
 }
@@ -193,6 +195,7 @@ pub fn crtp_channel_dispatcher(
 }
 
 /// Null implementation of ToC cache to be used when no caching is needed.
+#[derive(Clone)]
 pub struct NoTocCache;
 
 impl TocCache for NoTocCache {
@@ -200,7 +203,8 @@ impl TocCache for NoTocCache {
         None
     }
 
-    fn store_toc(&mut self, _crc32: u32, _toc: &str) {
+    fn store_toc(&self, _crc32: u32, _toc: &str) {
+        // No-op: this cache doesn't store anything
     }
 }
 
@@ -209,7 +213,38 @@ impl TocCache for NoTocCache {
 /// This trait provides methods for storing and retrieving TOC information
 /// using a CRC32 checksum as the key. Implementations can use this to avoid
 /// re-fetching TOC data when the checksum matches a cached version.
-pub trait TocCache
+///
+/// # Concurrency
+///
+/// Both methods take `&self` to allow concurrent reads during parallel TOC fetching
+/// (Log and Param subsystems fetch their TOCs simultaneously). Implementations should
+/// use interior mutability (e.g., `RwLock`) for thread-safe caching.
+///
+/// # Example
+///
+/// ```rust
+/// use std::sync::{Arc, RwLock};
+/// use std::collections::HashMap;
+/// use crazyflie_lib::TocCache;
+///
+/// #[derive(Clone)]
+/// struct InMemoryCache {
+///     data: Arc<RwLock<HashMap<u32, String>>>,
+/// }
+///
+/// impl TocCache for InMemoryCache {
+///     fn get_toc(&self, crc32: u32) -> Option<String> {
+///         self.data.read().ok()?.get(&crc32).cloned()
+///     }
+///
+///     fn store_toc(&self, crc32: u32, toc: &str) {
+///         if let Ok(mut lock) = self.data.write() {
+///             lock.insert(crc32, toc.to_string());
+///         }
+///     }
+/// }
+/// ```
+pub trait TocCache: Clone + Send + Sync + 'static
 {
     /// Retrieves a cached TOC string based on the provided CRC32 checksum.
     ///
@@ -227,6 +262,6 @@ pub trait TocCache
     /// # Arguments
     ///
     /// * `crc32` - The CRC32 checksum used to identify the TOC.
-    /// * `toc` - The TOC string to be stored. 
-    fn store_toc(&mut self, crc32: u32, toc: &str);
+    /// * `toc` - The TOC string to be stored.
+    fn store_toc(&self, crc32: u32, toc: &str);
 }

--- a/src/subsystems/log.rs
+++ b/src/subsystems/log.rs
@@ -81,10 +81,10 @@ impl Log {
     pub(crate) async fn new<T>(
         downlink: channel::Receiver<Packet>,
         uplink: channel::Sender<Packet>,
-        toc_cache: Arc<Mutex<T>>,
+        toc_cache: T,
     ) -> Result<Self>
     where
-        T: TocCache + Send + Sync + 'static,
+        T: TocCache,
     {
         let (toc_downlink, control_downlink, data_downlink, _) =
             crate::crtp_utils::crtp_channel_dispatcher(downlink);

--- a/src/subsystems/param.rs
+++ b/src/subsystems/param.rs
@@ -92,10 +92,10 @@ impl Param {
     pub(crate) async fn new<T>(
         downlink: channel::Receiver<Packet>,
         uplink: channel::Sender<Packet>,
-        toc_cache: Arc<Mutex<T>>,
+        toc_cache: T,
     ) -> Result<Self>
     where
-        T: TocCache + Send + Sync + 'static,
+        T: TocCache,
     {
         let (toc_downlink, read_downlink, write_downlink, misc_downlink) =
             crate::crtp_utils::crtp_channel_dispatcher(downlink);


### PR DESCRIPTION
The current implementation locks the cache twice for every access. The trait has store_toc taking &mut self, which seems reasonable for mutation. But since Log and Param both need the same cache (shared via cloning), implementations have to use Arc anyway. And you can't mutate through Arc even with &mut self - you still need a Mutex inside. So what happens is:
1. The library wraps the cache in Arc<Mutex<>> (to get &mut self for store_toc)
2. The implementation also has a Mutex inside (to actually mutate the HashMap)
3. Every cache access locks both

Cleaned this up to:
- Both trait methods take &self (since interior mutability is required anyway)
- Added Clone + Send + Sync to the trait
- Removed Arc<Mutex<>> wrapper - implementations handle locking
- Updated example to use RwLock for concurrent reads

Benchmarked and performance is identical, but it removes the double-locking.