### PR TITLE
Added DeckCtrl memory type and serial

### DIFF
--- a/src/subsystems/memory/memory_types.rs
+++ b/src/subsystems/memory/memory_types.rs
@@ -33,7 +33,7 @@ pub struct MemoryDevice {
     /// Size of the memory in bytes
     pub size: u32,
     /// Serial number of the memory
-    pub serial: Option<[u8; 12]>,
+    pub serial: Option<Vec<u8>>,
 }
 
 impl MemoryBackend {

--- a/src/subsystems/memory/mod.rs
+++ b/src/subsystems/memory/mod.rs
@@ -131,15 +131,7 @@ impl Memory {
         let memory_id = data[1];
         let memory_type = MemoryType::try_from(data[2])?;
         let memory_size = u32::from_le_bytes(data[3..7].try_into()?);
-        // This is 12 bytes for the new DeckCtrl type but 8 for the old 1-wire and is sent as such for
-        // older versions of the firmware.
-        let mut raw_memory_serial = [0u8; 12];
-
-        if data.len() >= 19 {
-          raw_memory_serial.copy_from_slice(&data[7..19]);
-        } else {
-          raw_memory_serial[4..12].copy_from_slice(&data[7..15]);
-        }
+        let raw_memory_serial = Vec::from(&data[7..]);
 
         let memory_serial = if raw_memory_serial.iter().all(|&b| b == 0) {
           None


### PR DESCRIPTION
This PR adds the type DeckCtrl as well as saving the memory serial number which is read from the Crazyflie. It supports both 8 and 12 bytes serial numbers.