### PR TITLE
Add expected/found versions to ProtocolVersionNotSupported error

### DIFF
--- a/src/crazyflie.rs
+++ b/src/crazyflie.rs
@@ -9,7 +9,7 @@ use crate::subsystems::param::Param;
 use crate::crtp_utils::{CrtpDispatch, TocCache};
 use crate::subsystems::platform::Platform;
 use crate::{Error, Result};
-use crate::SUPPORTED_PROTOCOL_VERSION;
+use crate::{MIN_SUPPORTED_PROTOCOL_VERSION, MAX_SUPPORTED_PROTOCOL_VERSION};
 use flume as channel;
 use futures::lock::Mutex;
 use tokio::task::JoinHandle;
@@ -140,11 +140,12 @@ impl Crazyflie {
 
         let protocol_version = platform.protocol_version().await?;
 
-        if !(SUPPORTED_PROTOCOL_VERSION..=(SUPPORTED_PROTOCOL_VERSION + 1))
+        if !(MIN_SUPPORTED_PROTOCOL_VERSION..=MAX_SUPPORTED_PROTOCOL_VERSION)
             .contains(&protocol_version)
         {
             return Err(Error::ProtocolVersionNotSupported {
-                expected: SUPPORTED_PROTOCOL_VERSION,
+                min_supported: MIN_SUPPORTED_PROTOCOL_VERSION,
+                max_supported: MAX_SUPPORTED_PROTOCOL_VERSION,
                 found: protocol_version,
             });
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,8 +13,10 @@ pub enum Error {
     ///
     /// see [the crate documentation](crate#compatibility) for more information.
     ProtocolVersionNotSupported {
-        /// The protocol version expected by this library
-        expected: u8,
+        /// The minimum protocol version supported by this library
+        min_supported: u8,
+        /// The maximum protocol version supported by this library
+        max_supported: u8,
         /// The protocol version found on the Crazyflie
         found: u8,
     },
@@ -50,8 +52,8 @@ pub enum Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::ProtocolVersionNotSupported { expected, found } => {
-                write!(f, "Protocol version not supported: expected {}, found {}", expected, found)
+            Error::ProtocolVersionNotSupported { min_supported, max_supported, found } => {
+                write!(f, "Protocol version not supported: supported range is {}-{}, found {}", min_supported, max_supported, found)
             }
             Error::ProtocolError(msg) => write!(f, "Protocol error: {}", msg),
             Error::ParamError(msg) => write!(f, "Parameter error: {}", msg),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,9 @@
 //!
 //! ## Compatibility
 //!
-//! This crate is compatible with Crazyflie protocol version >= [`SUPPORTED_PROTOCOL_VERSION`].
+//! This crate is compatible with Crazyflie protocol versions [`MIN_SUPPORTED_PROTOCOL_VERSION`]
+//! to [`MAX_SUPPORTED_PROTOCOL_VERSION`]. The Crazyflie guarantees backward compatibility for one
+//! protocol version, so this library will work with both the current and next protocol version.
 //!
 //! ## Usage
 //!
@@ -86,7 +88,12 @@ pub use crate::value::{Value, ValueType};
 pub use crate::crtp_utils::TocCache;
 pub use crate::crtp_utils::NoTocCache;
 
-/// Supported protocol version
+/// Minimum supported protocol version
 ///
 /// see [the crate documentation](crate#compatibility) for more information.
-pub const SUPPORTED_PROTOCOL_VERSION: u8 = 10;
+pub const MIN_SUPPORTED_PROTOCOL_VERSION: u8 = 10;
+
+/// Maximum supported protocol version
+///
+/// see [the crate documentation](crate#compatibility) for more information.
+pub const MAX_SUPPORTED_PROTOCOL_VERSION: u8 = MIN_SUPPORTED_PROTOCOL_VERSION + 1;


### PR DESCRIPTION
Include the expected and actual protocol version numbers in the error to help users diagnose version mismatches between the library and their Crazyflie firmware.