### PR TITLE
Fix console stream methods duplicating messages

### DIFF
--- a/examples/console.rs
+++ b/examples/console.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-        let mut console_stream = cf.console.line_stream_no_history().await;
+        let mut console_stream = cf.console.line_stream().await;
 
         while let Ok(Some(line)) = timeout(Duration::from_secs(10), console_stream.next()).await {
             println!("{}", line);

--- a/src/subsystems/console.rs
+++ b/src/subsystems/console.rs
@@ -136,13 +136,13 @@ impl Console {
         let history_buffer = buffer.clone();
         let history_stream = futures::stream::once(async { history_buffer }).boxed();
 
-        history_stream.chain(self.stream_broadcast_receiver.clone())
+        history_stream.chain(self.stream_broadcast_receiver.new_receiver())
     }
 
     /// Version of [Console::stream()] but that does not produce the history
     /// first.
     pub async fn stream_no_history(&self) -> impl Stream<Item = String> + use<> {
-        self.stream_broadcast_receiver.clone()
+        self.stream_broadcast_receiver.new_receiver()
     }
 
     /// Return a [Stream] that generate a [String] each time a line is received
@@ -159,12 +159,12 @@ impl Console {
         let history_lines = lines.clone();
         let history_stream = futures::stream::iter(history_lines.into_iter()).boxed();
 
-        history_stream.chain(self.line_broadcast_receiver.clone())
+        history_stream.chain(self.line_broadcast_receiver.new_receiver())
     }
 
     /// Version of [Console::line_stream()] but that does not produce the history
     /// first.
     pub async fn line_stream_no_history(&self) -> impl Stream<Item = String> + use<> {
-        self.line_broadcast_receiver.clone()
+        self.line_broadcast_receiver.new_receiver()
     }
 }


### PR DESCRIPTION
Use new_receiver() instead of clone() when creating console streams. Cloning a broadcast receiver shares the buffer position with the original, so messages still in the buffer would be returned. This caused the no_history variants to show history anyway, and the regular variants to show history twice.

Also update console example to use line_stream() with history.