### PR TITLE
Expose has_extended_type() on param subsystem

### DIFF
--- a/examples/persistent.rs
+++ b/examples/persistent.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     let test_param = "ring.effect";
     if !cf.param.has_extended_type(test_param)? {
-        return Err(format!("{} is known to have extended type", test_param).into());
+        return Err(format!("{} is expected to have extended type, but TOC reports none", test_param).into());
     }
     let extended_type = cf.param.get_extended_type(test_param).await?;
     println!("{} extended type: 0x{:02x}", test_param, extended_type);

--- a/examples/persistent.rs
+++ b/examples/persistent.rs
@@ -17,13 +17,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Checking Extended Type Support ===");
     
     let test_param = "ring.effect";
-    match cf.param.get_extended_type(test_param).await {
-        Ok(extended_type) => {
-            println!("{} extended type: 0x{:02x}", test_param, extended_type);
-            println!("  PERSISTENT flag: {}", if (extended_type & 0x01) != 0 { "Yes" } else { "No" });
-        }
-        Err(e) => println!("Error getting extended type: {}", e),
+    if !cf.param.has_extended_type(test_param)? {
+        return Err(format!("{} is known to have extended type", test_param).into());
     }
+    let extended_type = cf.param.get_extended_type(test_param).await?;
+    println!("{} extended type: 0x{:02x}", test_param, extended_type);
+    println!("  PERSISTENT flag: {}", if (extended_type & 0x01) != 0 { "Yes" } else { "No" });
     
     println!("\n=== Persistent Parameters ===");
     let mut persistent_params = Vec::new();

--- a/src/subsystems/param.rs
+++ b/src/subsystems/param.rs
@@ -275,6 +275,18 @@ impl Param {
             .writable)
     }
 
+    /// Return true if the parameter has extended type information.
+    ///
+    /// Return an error if the parameter does not exist.
+    pub fn has_extended_type(&self, name: &str) -> Result<bool> {
+        Ok(self
+            .toc
+            .get(name)
+            .ok_or_else(|| not_found(name))?
+            .1
+            .has_extended_type)
+    }
+
     /// Set a parameter value.
     ///
     /// This function will set the variable value and wait for confirmation from the
@@ -512,7 +524,14 @@ impl Param {
     ///
     /// Returns an error if the parameter does not exist or does not have extended type information.
     pub async fn get_extended_type(&self, name: &str) -> Result<u8> {
-        let (param_id, _) = self.toc.get(name).ok_or_else(|| not_found(name))?;
+        let (param_id, param_info) = self.toc.get(name).ok_or_else(|| not_found(name))?;
+
+        if !param_info.has_extended_type {
+            return Err(Error::ParamError(format!(
+                "Parameter '{}' does not have extended type info",
+                name
+            )));
+        }
 
         // Send request: [CMD(1), ID(2)]
         let request_data = vec![


### PR DESCRIPTION
Allow callers to check from the TOC whether a parameter supports extended type queries. Also guard get_extended_type() to return an early error instead of making a pointless firmware round-trip when the TOC already indicates no extended type support.