### PR TITLE
Update param subscription

### DIFF
--- a/examples/test_params.rs
+++ b/examples/test_params.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
 
     // Launch a task to watch param changes
-    let mut param_watcher = crazyflie.param.watch_change().await;
+    let mut param_watcher = crazyflie.param.watch_change().await?;
     tokio::spawn(async move {
         while let Some((name, value)) = param_watcher.next().await {
             println!(
@@ -49,6 +49,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     let val = crazyflie.param.get_lossy("pid_attitude.yaw_kd").await?;
     println!("Param value: {}", val);
+
+    println!("Disconnecting...");
+    crazyflie.disconnect().await;
+    println!("Done.");
+
+    println!("Trying to watch parameter changes...");
+    let param_watcher_2 = crazyflie.param.watch_change().await;
+    match param_watcher_2 {
+        Ok(_) => println!("This should not happen - no Crazyflie connected"),
+        Err(msg) => println!("Watching changes is not possible when no Crazyflie is connected. This is correct! Error message: {msg}")
+    }
 
     Ok(())
 }

--- a/examples/test_params.rs
+++ b/examples/test_params.rs
@@ -4,10 +4,15 @@ use futures::StreamExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let uri = std::env::args()
+        .skip_while(|a| a != "--uri")
+        .nth(1)
+        .unwrap_or_else(|| "radio://0/60/2M/E7E7E7E7E7".to_string());
+
     let context = LinkContext::new();
     let crazyflie = Crazyflie::connect_from_uri(
         &context,
-        "radio://0/60/2M/E7E7E7E7E7",
+        &uri,
         crazyflie_lib::NoTocCache
     )
     .await?;

--- a/examples/test_params.rs
+++ b/examples/test_params.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Trying to watch parameter changes...");
     let param_watcher_2 = crazyflie.param.watch_change().await;
     match param_watcher_2 {
-        Ok(_) => println!("This should not happen - no Crazyflie connected"),
+        Ok(_) => unreachable!("watch_change() should have returned an error when no Crazyflie is connected."),
         Err(msg) => println!("Watching changes is not possible when no Crazyflie is connected. This is correct! Error message: {msg}")
     }
 

--- a/src/subsystems/param.rs
+++ b/src/subsystems/param.rs
@@ -242,6 +242,7 @@ impl Param {
                 }
             }
             values.lock().await.clear();
+            watchers.lock().await.clear(); // Drops all tx senders and makes rx return None on .next()
         });
     }
 

--- a/src/subsystems/param.rs
+++ b/src/subsystems/param.rs
@@ -487,7 +487,7 @@ impl Param {
     ///    will send notification packet for every internal parameter change.
     pub async fn watch_change(&self) -> Result<impl futures::Stream<Item = (String, Value)> + use<>> {
         if self.uplink.is_disconnected() {
-            return Err(Error::Disconnected)
+            return Err(Error::Disconnected);
         }
         let (tx, rx) = futures::channel::mpsc::unbounded();
 

--- a/src/subsystems/param.rs
+++ b/src/subsystems/param.rs
@@ -485,13 +485,16 @@ impl Param {
     ///    has been set.
     ///  - Or it can be a parameter change in the Crazyflie itself. The Crazyflie
     ///    will send notification packet for every internal parameter change.
-    pub async fn watch_change(&self) -> impl futures::Stream<Item = (String, Value)> + use<> {
+    pub async fn watch_change(&self) -> Result<impl futures::Stream<Item = (String, Value)> + use<>> {
+        if self.uplink.is_disconnected() {
+            return Err(Error::Disconnected)
+        }
         let (tx, rx) = futures::channel::mpsc::unbounded();
 
         let mut watchers = self.watchers.lock().await;
         watchers.push(tx);
 
-        rx
+        Ok(rx)
     }
 
     /// Check if a parameter supports persistent storage

--- a/src/subsystems/param.rs
+++ b/src/subsystems/param.rs
@@ -242,7 +242,7 @@ impl Param {
                 }
             }
             values.lock().await.clear();
-            watchers.lock().await.clear(); // Drops all tx senders and makes rx return None on .next()
+            watchers.lock().await.clear(); // Drops all tx senders, killing the stream
         });
     }
 


### PR DESCRIPTION
- Make watch_change return Err if disconnected
- Make watch_change return type Result<...> (Breaking API change)
- Add negative test to test_params.py: watch_change() should return Err if disconnected
- Kill stream on disconnect (clear watchers vector)