### PR TITLE
Pipeline MemoryBackend read and write

### DIFF
--- a/src/subsystems/memory/memory_types.rs
+++ b/src/subsystems/memory/memory_types.rs
@@ -13,6 +13,58 @@ const WRITE_CHANNEL: u8 = 2;
 const MEM_MAX_REQUEST_SIZE: usize = 24;
 const PIPELINE_DEPTH: usize = 16;
 
+/// Drain the responses for the `count` requests still in flight after a
+/// protocol error, so leftover packets don't desync the next operation on the
+/// same (persistent) downlink channel. Operations on a backend are serialized
+/// (the backend is moved out of its slot for the duration), so every packet on
+/// the channel belongs to this operation.
+///
+/// No timeout: a protocol error means the firmware is responding, so the
+/// remaining in-order responses are expected to follow. We stop early only if
+/// the link drops (receive error), since no further packets can then arrive.
+async fn drain_in_flight(downlink: &channel::Receiver<Packet>, count: usize) {
+    for _ in 0..count {
+        if downlink.recv_async().await.is_err() {
+            break;
+        }
+    }
+}
+
+/// Validate a memory read response and return its payload bytes.
+fn parse_read_response(pk_data: &[u8], expected_len: usize, chunk_address: usize) -> Result<&[u8]> {
+    if pk_data.len() < 6 {
+        return Err(Error::MemoryError("Malformed memory read response".into()));
+    }
+    let status = pk_data[5];
+    if status != 0 {
+        return Err(Error::MemoryError(format!(
+            "Memory read returned error status ({}) @ {}", status, chunk_address
+        )));
+    }
+    let read_data = &pk_data[6..];
+    if read_data.len() != expected_len {
+        return Err(Error::MemoryError(format!(
+            "Unexpected memory read response length @ {}: expected {} bytes, got {}",
+            chunk_address, expected_len, read_data.len()
+        )));
+    }
+    Ok(read_data)
+}
+
+/// Validate a memory write response (ack).
+fn parse_write_response(pk_data: &[u8], chunk_address: usize) -> Result<()> {
+    if pk_data.len() < 6 {
+        return Err(Error::MemoryError("Malformed memory write response".into()));
+    }
+    let status = pk_data[5];
+    if status != 0 {
+        return Err(Error::MemoryError(format!(
+            "Memory write returned error status ({}) @ {}", status, chunk_address
+        )));
+    }
+    Ok(())
+}
+
 
 /// Description of a memory in the Crazyflie
 #[derive(Debug)]
@@ -53,6 +105,11 @@ impl MemoryBackend {
         let mut in_flight: VecDeque<(usize, [u8; 5], usize)> =
             VecDeque::with_capacity(PIPELINE_DEPTH);
 
+        // Transport errors (send/receive) propagate as-is via `?`: they are
+        // almost certainly a disconnect, so no more packets will arrive and
+        // draining is impossible. A protocol error (bad data from the firmware)
+        // instead drains the still in-flight responses first, so they don't
+        // desync the next call.
         while next_send_address < end_address || !in_flight.is_empty() {
             while in_flight.len() < PIPELINE_DEPTH && next_send_address < end_address {
                 let to_read = std::cmp::min(
@@ -78,26 +135,15 @@ impl MemoryBackend {
                 .await?;
             in_flight.pop_front();
 
-            let pk_data = pk.get_data();
-            if pk_data.len() < 6 {
-                return Err(Error::MemoryError("Malformed memory read response".into()));
-            }
-            let status = pk_data[5];
-            if status != 0 {
-                return Err(Error::MemoryError(format!(
-                    "Memory read returned error status ({}) @ {}", status, chunk_address
-                )));
-            }
-            let read_data = &pk_data[6..];
-            if read_data.len() != to_read {
-                return Err(Error::MemoryError(format!(
-                    "Unexpected memory read response length @ {}: expected {} bytes, got {}",
-                    chunk_address, to_read, read_data.len()
-                )));
-            }
+            let read_data = match parse_read_response(pk.get_data(), to_read, chunk_address) {
+                Ok(read_data) => read_data,
+                Err(e) => {
+                    drain_in_flight(&self.read_downlink, in_flight.len()).await;
+                    return Err(e);
+                }
+            };
             let start = chunk_address - address;
-            let end = start + read_data.len();
-            data[start..end].copy_from_slice(read_data);
+            data[start..start + read_data.len()].copy_from_slice(read_data);
 
             if let Some(ref mut callback) = progress_callback {
                 let confirmed_end = in_flight
@@ -151,16 +197,9 @@ impl MemoryBackend {
                 .await?;
             in_flight.pop_front();
 
-            let pk_data = pk.get_data();
-            if pk_data.len() < 6 {
-                return Err(Error::MemoryError("Malformed memory write response".into()));
-            }
-            let status = pk_data[5];
-            if status != 0 {
-                return Err(Error::MemoryError(format!(
-                    "Memory write returned error status ({}) @ {}",
-                    status, chunk_address
-                )));
+            if let Err(e) = parse_write_response(pk.get_data(), chunk_address) {
+                drain_in_flight(&self.write_downlink, in_flight.len()).await;
+                return Err(e);
             }
 
             if let Some(ref mut callback) = progress_callback {

--- a/src/subsystems/memory/memory_types.rs
+++ b/src/subsystems/memory/memory_types.rs
@@ -1,10 +1,9 @@
-use crate::{Error, Result};
+use crate::{crtp_utils::WaitForPacket, Error, Result};
 use crazyflie_link::Packet;
 use flume as channel;
 use std::collections::VecDeque;
 use std::convert::TryFrom;
 use std::str::FromStr;
-use std::time::Duration;
 
 use crate::crazyflie::MEMORY_PORT;
 
@@ -13,30 +12,6 @@ const WRITE_CHANNEL: u8 = 2;
 
 const MEM_MAX_REQUEST_SIZE: usize = 24;
 const PIPELINE_DEPTH: usize = 16;
-
-// Single overall deadline used after an error to consume responses for
-// requests we already put on the wire. Without this, a later read()/write()
-// could match the stale reply.
-const DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
-
-// Consume up to `count` packets from `downlink`, bounded by DRAIN_TIMEOUT in
-// total. The dispatcher in memory/mod.rs has already filtered the channel by
-// (channel, memory_id), so the only thing we need to do is empty it.
-async fn drain_pending(downlink: &channel::Receiver<Packet>, count: usize) {
-    let deadline = tokio::time::Instant::now() + DRAIN_TIMEOUT;
-    for _ in 0..count {
-        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-        if remaining.is_zero() {
-            break;
-        }
-        if tokio::time::timeout(remaining, downlink.recv_async())
-            .await
-            .is_err()
-        {
-            break;
-        }
-    }
-}
 
 
 /// Description of a memory in the Crazyflie
@@ -70,8 +45,7 @@ impl MemoryBackend {
         F: FnMut(usize, usize),
     {
         // Responses arrive in send order (single firmware mem task), so we
-        // can match by front-of-queue prefix. The [memory_id, address] prefix
-        // also makes any address check on the response redundant.
+        // can match by front-of-queue prefix.
         let mut data = vec![0; length];
         let end_address = address + length;
         let mut next_send_address = address;
@@ -79,77 +53,62 @@ impl MemoryBackend {
         let mut in_flight: VecDeque<(usize, [u8; 5], usize)> =
             VecDeque::with_capacity(PIPELINE_DEPTH);
 
-        let result: Result<()> = async {
-            while next_send_address < end_address || !in_flight.is_empty() {
-                while in_flight.len() < PIPELINE_DEPTH && next_send_address < end_address {
-                    let to_read = std::cmp::min(
-                        MEM_MAX_REQUEST_SIZE,
-                        end_address - next_send_address,
-                    );
-                    let mut request_data = Vec::new();
-                    request_data.extend_from_slice(&self.memory_id.to_le_bytes());
-                    request_data.extend_from_slice(&(next_send_address as u32).to_le_bytes());
-                    request_data.extend_from_slice(&(to_read as u8).to_le_bytes());
-                    let mut prefix = [0u8; 5];
-                    prefix.copy_from_slice(&request_data[0..5]);
-                    let pk = Packet::new(MEMORY_PORT, READ_CHANNEL, request_data);
-                    self.uplink.send_async(pk).await?;
-                    in_flight.push_back((next_send_address, prefix, to_read));
-                    next_send_address += to_read;
-                }
-
-                let (chunk_address, prefix, to_read) = *in_flight.front().expect("non-empty");
-                let pk = self
-                    .read_downlink
-                    .recv_async()
-                    .await
-                    .map_err(|_| Error::Disconnected)?;
-                in_flight.pop_front();
-
-                let pk_data = pk.get_data();
-                if pk_data.len() < 6 {
-                    return Err(Error::MemoryError("Malformed memory read response".into()));
-                }
-                if pk_data[..5] != prefix {
-                    return Err(Error::MemoryError(format!(
-                        "Out-of-order memory read response: expected prefix {:02x?}, got {:02x?}",
-                        prefix, &pk_data[..5]
-                    )));
-                }
-                let status = pk_data[5];
-                if status != 0 {
-                    return Err(Error::MemoryError(format!(
-                        "Memory read returned error status ({}) @ {}", status, chunk_address
-                    )));
-                }
-                let read_data = &pk_data[6..];
-                if read_data.len() != to_read {
-                    return Err(Error::MemoryError(format!(
-                        "Short memory read response @ {}: expected {} bytes, got {}",
-                        chunk_address, to_read, read_data.len()
-                    )));
-                }
-                let start = chunk_address - address;
-                let end = start + read_data.len();
-                data[start..end].copy_from_slice(read_data);
-
-                if let Some(ref mut callback) = progress_callback {
-                    let confirmed_end = in_flight
-                        .front()
-                        .map(|(addr, _, _)| *addr)
-                        .unwrap_or(next_send_address);
-                    callback(confirmed_end - address, length);
-                }
+        while next_send_address < end_address || !in_flight.is_empty() {
+            while in_flight.len() < PIPELINE_DEPTH && next_send_address < end_address {
+                let to_read = std::cmp::min(
+                    MEM_MAX_REQUEST_SIZE,
+                    end_address - next_send_address,
+                );
+                let mut request_data = Vec::new();
+                request_data.extend_from_slice(&self.memory_id.to_le_bytes());
+                request_data.extend_from_slice(&(next_send_address as u32).to_le_bytes());
+                request_data.extend_from_slice(&(to_read as u8).to_le_bytes());
+                let mut prefix = [0u8; 5];
+                prefix.copy_from_slice(&request_data[0..5]);
+                let pk = Packet::new(MEMORY_PORT, READ_CHANNEL, request_data);
+                self.uplink.send_async(pk).await?;
+                in_flight.push_back((next_send_address, prefix, to_read));
+                next_send_address += to_read;
             }
-            Ok(())
-        }
-        .await;
 
-        if result.is_err() {
-            drain_pending(&self.read_downlink, in_flight.len()).await;
+            let (chunk_address, prefix, to_read) = *in_flight.front().expect("non-empty");
+            let pk = self
+                .read_downlink
+                .wait_packet(MEMORY_PORT, READ_CHANNEL, &prefix)
+                .await?;
+            in_flight.pop_front();
+
+            let pk_data = pk.get_data();
+            if pk_data.len() < 6 {
+                return Err(Error::MemoryError("Malformed memory read response".into()));
+            }
+            let status = pk_data[5];
+            if status != 0 {
+                return Err(Error::MemoryError(format!(
+                    "Memory read returned error status ({}) @ {}", status, chunk_address
+                )));
+            }
+            let read_data = &pk_data[6..];
+            if read_data.len() != to_read {
+                return Err(Error::MemoryError(format!(
+                    "Short memory read response @ {}: expected {} bytes, got {}",
+                    chunk_address, to_read, read_data.len()
+                )));
+            }
+            let start = chunk_address - address;
+            let end = start + read_data.len();
+            data[start..end].copy_from_slice(read_data);
+
+            if let Some(ref mut callback) = progress_callback {
+                let confirmed_end = in_flight
+                    .front()
+                    .map(|(addr, _, _)| *addr)
+                    .unwrap_or(next_send_address);
+                callback(confirmed_end - address, length);
+            }
         }
 
-        result.map(|_| data)
+        Ok(data)
     }
 
     pub(crate) async fn write<F>(&self, address: usize, data: &[u8], mut progress_callback: Option<F>) -> Result<()>
@@ -165,70 +124,54 @@ impl MemoryBackend {
         let mut in_flight: VecDeque<(usize, [u8; 5])> =
             VecDeque::with_capacity(PIPELINE_DEPTH);
 
-        let result: Result<()> = async {
-            while next_send_address < end_address || !in_flight.is_empty() {
-                while in_flight.len() < PIPELINE_DEPTH && next_send_address < end_address {
-                    let to_write = std::cmp::min(
-                        MEM_MAX_REQUEST_SIZE,
-                        end_address - next_send_address,
-                    );
-                    let start = next_send_address - address;
-                    let end = start + to_write;
-                    let mut request_data = Vec::new();
-                    request_data.extend_from_slice(&self.memory_id.to_le_bytes());
-                    request_data.extend_from_slice(&(next_send_address as u32).to_le_bytes());
-                    request_data.extend_from_slice(&data[start..end]);
-                    let mut prefix = [0u8; 5];
-                    prefix.copy_from_slice(&request_data[0..5]);
-                    let pk = Packet::new(MEMORY_PORT, WRITE_CHANNEL, request_data);
-                    self.uplink.send_async(pk).await?;
-                    in_flight.push_back((next_send_address, prefix));
-                    next_send_address += to_write;
-                }
-
-                let (chunk_address, prefix) = *in_flight.front().expect("non-empty by loop guard");
-                let pk = self
-                    .write_downlink
-                    .recv_async()
-                    .await
-                    .map_err(|_| Error::Disconnected)?;
-                in_flight.pop_front();
-
-                let pk_data = pk.get_data();
-                if pk_data.len() < 6 {
-                    return Err(Error::MemoryError("Malformed memory write response".into()));
-                }
-                if pk_data[..5] != prefix {
-                    return Err(Error::MemoryError(format!(
-                        "Out-of-order memory write response: expected prefix {:02x?}, got {:02x?}",
-                        prefix, &pk_data[..5]
-                    )));
-                }
-                let status = pk_data[5];
-                if status != 0 {
-                    return Err(Error::MemoryError(format!(
-                        "Memory write returned error status ({}) @ {}",
-                        status, chunk_address
-                    )));
-                }
-
-                if let Some(ref mut callback) = progress_callback {
-                    let confirmed_end = in_flight
-                        .front()
-                        .map(|(addr, _)| *addr)
-                        .unwrap_or(next_send_address);
-                    callback(confirmed_end - address, length);
-                }
+        while next_send_address < end_address || !in_flight.is_empty() {
+            while in_flight.len() < PIPELINE_DEPTH && next_send_address < end_address {
+                let to_write = std::cmp::min(
+                    MEM_MAX_REQUEST_SIZE,
+                    end_address - next_send_address,
+                );
+                let start = next_send_address - address;
+                let end = start + to_write;
+                let mut request_data = Vec::new();
+                request_data.extend_from_slice(&self.memory_id.to_le_bytes());
+                request_data.extend_from_slice(&(next_send_address as u32).to_le_bytes());
+                request_data.extend_from_slice(&data[start..end]);
+                let mut prefix = [0u8; 5];
+                prefix.copy_from_slice(&request_data[0..5]);
+                let pk = Packet::new(MEMORY_PORT, WRITE_CHANNEL, request_data);
+                self.uplink.send_async(pk).await?;
+                in_flight.push_back((next_send_address, prefix));
+                next_send_address += to_write;
             }
-            Ok(())
-        }
-        .await;
 
-        if result.is_err() {
-            drain_pending(&self.write_downlink, in_flight.len()).await;
-        }
+            let (chunk_address, prefix) = *in_flight.front().expect("non-empty by loop guard");
+            let pk = self
+                .write_downlink
+                .wait_packet(MEMORY_PORT, WRITE_CHANNEL, &prefix)
+                .await?;
+            in_flight.pop_front();
 
-        result
+            let pk_data = pk.get_data();
+            if pk_data.len() < 6 {
+                return Err(Error::MemoryError("Malformed memory write response".into()));
+            }
+            let status = pk_data[5];
+            if status != 0 {
+                return Err(Error::MemoryError(format!(
+                    "Memory write returned error status ({}) @ {}",
+                    status, chunk_address
+                )));
+            }
+
+            if let Some(ref mut callback) = progress_callback {
+                let confirmed_end = in_flight
+                    .front()
+                    .map(|(addr, _)| *addr)
+                    .unwrap_or(next_send_address);
+                callback(confirmed_end - address, length);
+            }
+        }
+        Ok(())
     }
 }
 

--- a/src/subsystems/memory/memory_types.rs
+++ b/src/subsystems/memory/memory_types.rs
@@ -1,4 +1,4 @@
-use crate::{crtp_utils::WaitForPacket, Error, Result};
+use crate::{Error, Result};
 use crazyflie_link::Packet;
 use flume as channel;
 use std::collections::VecDeque;
@@ -14,27 +14,26 @@ const WRITE_CHANNEL: u8 = 2;
 const MEM_MAX_REQUEST_SIZE: usize = 24;
 const PIPELINE_DEPTH: usize = 16;
 
-// Best-effort bounded wait used after an error to consume responses for
+// Single overall deadline used after an error to consume responses for
 // requests we already put on the wire. Without this, a later read()/write()
-// to the same prefix could match the stale reply.
+// could match the stale reply.
 const DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
 
-async fn drain_pending(
-    downlink: &channel::Receiver<Packet>,
-    channel_id: u8,
-    pending: &mut VecDeque<[u8; 5]>,
-) {
-    while let Some(&prefix) = pending.front() {
-        match tokio::time::timeout(
-            DRAIN_TIMEOUT,
-            downlink.wait_packet(MEMORY_PORT, channel_id, &prefix),
-        )
-        .await
+// Consume up to `count` packets from `downlink`, bounded by DRAIN_TIMEOUT in
+// total. The dispatcher in memory/mod.rs has already filtered the channel by
+// (channel, memory_id), so the only thing we need to do is empty it.
+async fn drain_pending(downlink: &channel::Receiver<Packet>, count: usize) {
+    let deadline = tokio::time::Instant::now() + DRAIN_TIMEOUT;
+    for _ in 0..count {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        if tokio::time::timeout(remaining, downlink.recv_async())
+            .await
+            .is_err()
         {
-            Ok(Ok(_)) => {
-                pending.pop_front();
-            }
-            _ => break,
+            break;
         }
     }
 }
@@ -102,13 +101,20 @@ impl MemoryBackend {
                 let (chunk_address, prefix, to_read) = *in_flight.front().expect("non-empty");
                 let pk = self
                     .read_downlink
-                    .wait_packet(MEMORY_PORT, READ_CHANNEL, &prefix)
-                    .await?;
+                    .recv_async()
+                    .await
+                    .map_err(|_| Error::Disconnected)?;
                 in_flight.pop_front();
 
                 let pk_data = pk.get_data();
                 if pk_data.len() < 6 {
                     return Err(Error::MemoryError("Malformed memory read response".into()));
+                }
+                if pk_data[..5] != prefix {
+                    return Err(Error::MemoryError(format!(
+                        "Out-of-order memory read response: expected prefix {:02x?}, got {:02x?}",
+                        prefix, &pk_data[..5]
+                    )));
                 }
                 let status = pk_data[5];
                 if status != 0 {
@@ -140,9 +146,7 @@ impl MemoryBackend {
         .await;
 
         if result.is_err() {
-            let mut pending: VecDeque<[u8; 5]> =
-                in_flight.iter().map(|(_, prefix, _)| *prefix).collect();
-            drain_pending(&self.read_downlink, READ_CHANNEL, &mut pending).await;
+            drain_pending(&self.read_downlink, in_flight.len()).await;
         }
 
         result.map(|_| data)
@@ -185,13 +189,20 @@ impl MemoryBackend {
                 let (chunk_address, prefix) = *in_flight.front().expect("non-empty by loop guard");
                 let pk = self
                     .write_downlink
-                    .wait_packet(MEMORY_PORT, WRITE_CHANNEL, &prefix)
-                    .await?;
+                    .recv_async()
+                    .await
+                    .map_err(|_| Error::Disconnected)?;
                 in_flight.pop_front();
 
                 let pk_data = pk.get_data();
                 if pk_data.len() < 6 {
                     return Err(Error::MemoryError("Malformed memory write response".into()));
+                }
+                if pk_data[..5] != prefix {
+                    return Err(Error::MemoryError(format!(
+                        "Out-of-order memory write response: expected prefix {:02x?}, got {:02x?}",
+                        prefix, &pk_data[..5]
+                    )));
                 }
                 let status = pk_data[5];
                 if status != 0 {
@@ -214,9 +225,7 @@ impl MemoryBackend {
         .await;
 
         if result.is_err() {
-            let mut pending: VecDeque<[u8; 5]> =
-                in_flight.iter().map(|(_, prefix)| *prefix).collect();
-            drain_pending(&self.write_downlink, WRITE_CHANNEL, &mut pending).await;
+            drain_pending(&self.write_downlink, in_flight.len()).await;
         }
 
         result

--- a/src/subsystems/memory/memory_types.rs
+++ b/src/subsystems/memory/memory_types.rs
@@ -42,53 +42,68 @@ impl MemoryBackend {
     where
         F: FnMut(usize, usize),
     {
-        let mut data = vec![0; length];
-        let mut current_address = address;
-        while current_address < address + length {
-            let to_read = std::cmp::min(
-                MEM_MAX_REQUEST_SIZE,
-                (address + length) - current_address,
-            );
-            let mut request_data = Vec::new();
-            request_data.extend_from_slice(&self.memory_id.to_le_bytes());
-            request_data.extend_from_slice(&(current_address as u32).to_le_bytes());
-            request_data.extend_from_slice(&(to_read as u8).to_le_bytes());
-            let pk = Packet::new(MEMORY_PORT, READ_CHANNEL, request_data.clone());
-            self.uplink
-                .send_async(pk)
-                .await?;
+        // Responses arrive in send order (single firmware mem task), so we
+        // can match by front-of-queue prefix.
+        const PIPELINE_DEPTH: usize = 16;
 
+        let mut data = vec![0; length];
+        let end_address = address + length;
+        let mut next_send_address = address;
+
+        let mut in_flight: std::collections::VecDeque<(usize, [u8; 5], usize)> =
+            std::collections::VecDeque::with_capacity(PIPELINE_DEPTH);
+
+        while next_send_address < end_address || !in_flight.is_empty() {
+            while in_flight.len() < PIPELINE_DEPTH && next_send_address < end_address {
+                let to_read = std::cmp::min(
+                    MEM_MAX_REQUEST_SIZE,
+                    end_address - next_send_address,
+                );
+                let mut request_data = Vec::new();
+                request_data.extend_from_slice(&self.memory_id.to_le_bytes());
+                request_data.extend_from_slice(&(next_send_address as u32).to_le_bytes());
+                request_data.extend_from_slice(&(to_read as u8).to_le_bytes());
+                let mut prefix = [0u8; 5];
+                prefix.copy_from_slice(&request_data[0..5]);
+                let pk = Packet::new(MEMORY_PORT, READ_CHANNEL, request_data);
+                self.uplink.send_async(pk).await?;
+                in_flight.push_back((next_send_address, prefix, to_read));
+                next_send_address += to_read;
+            }
+
+            let (chunk_address, prefix, _to_read) = *in_flight.front().expect("non-empty");
             let pk = self
                 .read_downlink
-                .wait_packet(MEMORY_PORT, READ_CHANNEL, &request_data[0..5])
+                .wait_packet(MEMORY_PORT, READ_CHANNEL, &prefix)
                 .await?;
+            in_flight.pop_front();
 
             let pk_data = pk.get_data();
-
             if pk_data.len() < 6 {
                 return Err(Error::MemoryError("Malformed memory read response".into()));
             }
-
             let read_address = u32::from_le_bytes(pk_data[1..5].try_into().unwrap());
             let status = pk_data[5];
-
-            if pk_data.len() >= 6 && read_address == current_address as u32 && status == 0 {
-                let read_data = &pk_data[6..];
-                let start = (current_address - address) as usize;
-                let end = start + read_data.len();
-                data[start..end].copy_from_slice(read_data);
-            } else if status != 0 {
-                return Err(Error::MemoryError(format!("Memory read returned error status ({}) @ {}", status, current_address)));
-            } else {
+            if status != 0 {
+                return Err(Error::MemoryError(format!(
+                    "Memory read returned error status ({}) @ {}", status, chunk_address
+                )));
+            }
+            if read_address != chunk_address as u32 {
                 return Err(Error::MemoryError("Malformed memory read response".into()));
             }
-
-            current_address += to_read;
+            let read_data = &pk_data[6..];
+            let start = chunk_address - address;
+            let end = start + read_data.len();
+            data[start..end].copy_from_slice(read_data);
 
             if let Some(ref mut callback) = progress_callback {
-                callback(current_address - address, length);
+                let confirmed_end = in_flight
+                    .front()
+                    .map(|(addr, _, _)| *addr)
+                    .unwrap_or(next_send_address);
+                callback(confirmed_end - address, length);
             }
-            
         }
 
         Ok(data)
@@ -98,46 +113,62 @@ impl MemoryBackend {
     where
         F: FnMut(usize, usize),
     {
-        let mut current_address = address;
+        // Responses arrive in send order (single firmware mem task), so we
+        // can match by front-of-queue prefix.
+        const PIPELINE_DEPTH: usize = 16;
+
         let length = data.len();
-        while current_address < address + length {
-            let to_write = std::cmp::min(
-                MEM_MAX_REQUEST_SIZE,
-                (address + length) - current_address,
-            );
-            let start = (current_address - address) as usize;
-            let end = start + to_write;
-            let mut request_data = Vec::new();
-            request_data.extend_from_slice(&self.memory_id.to_le_bytes());
-            request_data.extend_from_slice(&(current_address as u32).to_le_bytes());
-            request_data.extend_from_slice(&data[start..end]);
-            let pk = Packet::new(MEMORY_PORT, WRITE_CHANNEL, request_data.clone());
+        let end_address = address + length;
+        let mut next_send_address = address;
 
-            self.uplink
-                .send_async(pk)
-                .await?;
-            current_address += to_write;
+        let mut in_flight: std::collections::VecDeque<(usize, [u8; 5])> =
+            std::collections::VecDeque::with_capacity(PIPELINE_DEPTH);
 
-            if let Some(ref mut callback) = progress_callback {
-                callback(current_address - address, length);
+        while next_send_address < end_address || !in_flight.is_empty() {
+            while in_flight.len() < PIPELINE_DEPTH && next_send_address < end_address {
+                let to_write = std::cmp::min(
+                    MEM_MAX_REQUEST_SIZE,
+                    end_address - next_send_address,
+                );
+                let start = next_send_address - address;
+                let end = start + to_write;
+                let mut request_data = Vec::new();
+                request_data.extend_from_slice(&self.memory_id.to_le_bytes());
+                request_data.extend_from_slice(&(next_send_address as u32).to_le_bytes());
+                request_data.extend_from_slice(&data[start..end]);
+                let mut prefix = [0u8; 5];
+                prefix.copy_from_slice(&request_data[0..5]);
+                let pk = Packet::new(MEMORY_PORT, WRITE_CHANNEL, request_data);
+                self.uplink.send_async(pk).await?;
+                in_flight.push_back((next_send_address, prefix));
+                next_send_address += to_write;
             }
 
+            let (chunk_address, prefix) = *in_flight.front().expect("non-empty by loop guard");
             let pk = self
                 .write_downlink
-                .wait_packet(MEMORY_PORT, WRITE_CHANNEL, &request_data[0..5])
+                .wait_packet(MEMORY_PORT, WRITE_CHANNEL, &prefix)
                 .await?;
+            in_flight.pop_front();
+
             let pk_data = pk.get_data();
-            
             if pk_data.len() < 6 {
                 return Err(Error::MemoryError("Malformed memory write response".into()));
             }
-            
             let status = pk_data[5];
             if status != 0 {
                 return Err(Error::MemoryError(format!(
                     "Memory write returned error status ({}) @ {}",
-                    status, current_address - to_write
+                    status, chunk_address
                 )));
+            }
+
+            if let Some(ref mut callback) = progress_callback {
+                let confirmed_end = in_flight
+                    .front()
+                    .map(|(addr, _)| *addr)
+                    .unwrap_or(next_send_address);
+                callback(confirmed_end - address, length);
             }
         }
         Ok(())

--- a/src/subsystems/memory/memory_types.rs
+++ b/src/subsystems/memory/memory_types.rs
@@ -1,8 +1,10 @@
 use crate::{crtp_utils::WaitForPacket, Error, Result};
 use crazyflie_link::Packet;
 use flume as channel;
-use std::convert::{TryFrom, TryInto};
+use std::collections::VecDeque;
+use std::convert::TryFrom;
 use std::str::FromStr;
+use std::time::Duration;
 
 use crate::crazyflie::MEMORY_PORT;
 
@@ -10,6 +12,32 @@ const READ_CHANNEL: u8 = 1;
 const WRITE_CHANNEL: u8 = 2;
 
 const MEM_MAX_REQUEST_SIZE: usize = 24;
+const PIPELINE_DEPTH: usize = 16;
+
+// Best-effort bounded wait used after an error to consume responses for
+// requests we already put on the wire. Without this, a later read()/write()
+// to the same prefix could match the stale reply.
+const DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
+
+async fn drain_pending(
+    downlink: &channel::Receiver<Packet>,
+    channel_id: u8,
+    pending: &mut VecDeque<[u8; 5]>,
+) {
+    while let Some(&prefix) = pending.front() {
+        match tokio::time::timeout(
+            DRAIN_TIMEOUT,
+            downlink.wait_packet(MEMORY_PORT, channel_id, &prefix),
+        )
+        .await
+        {
+            Ok(Ok(_)) => {
+                pending.pop_front();
+            }
+            _ => break,
+        }
+    }
+}
 
 
 /// Description of a memory in the Crazyflie
@@ -43,70 +71,81 @@ impl MemoryBackend {
         F: FnMut(usize, usize),
     {
         // Responses arrive in send order (single firmware mem task), so we
-        // can match by front-of-queue prefix.
-        const PIPELINE_DEPTH: usize = 16;
-
+        // can match by front-of-queue prefix. The [memory_id, address] prefix
+        // also makes any address check on the response redundant.
         let mut data = vec![0; length];
         let end_address = address + length;
         let mut next_send_address = address;
 
-        let mut in_flight: std::collections::VecDeque<(usize, [u8; 5], usize)> =
-            std::collections::VecDeque::with_capacity(PIPELINE_DEPTH);
+        let mut in_flight: VecDeque<(usize, [u8; 5], usize)> =
+            VecDeque::with_capacity(PIPELINE_DEPTH);
 
-        while next_send_address < end_address || !in_flight.is_empty() {
-            while in_flight.len() < PIPELINE_DEPTH && next_send_address < end_address {
-                let to_read = std::cmp::min(
-                    MEM_MAX_REQUEST_SIZE,
-                    end_address - next_send_address,
-                );
-                let mut request_data = Vec::new();
-                request_data.extend_from_slice(&self.memory_id.to_le_bytes());
-                request_data.extend_from_slice(&(next_send_address as u32).to_le_bytes());
-                request_data.extend_from_slice(&(to_read as u8).to_le_bytes());
-                let mut prefix = [0u8; 5];
-                prefix.copy_from_slice(&request_data[0..5]);
-                let pk = Packet::new(MEMORY_PORT, READ_CHANNEL, request_data);
-                self.uplink.send_async(pk).await?;
-                in_flight.push_back((next_send_address, prefix, to_read));
-                next_send_address += to_read;
-            }
+        let result: Result<()> = async {
+            while next_send_address < end_address || !in_flight.is_empty() {
+                while in_flight.len() < PIPELINE_DEPTH && next_send_address < end_address {
+                    let to_read = std::cmp::min(
+                        MEM_MAX_REQUEST_SIZE,
+                        end_address - next_send_address,
+                    );
+                    let mut request_data = Vec::new();
+                    request_data.extend_from_slice(&self.memory_id.to_le_bytes());
+                    request_data.extend_from_slice(&(next_send_address as u32).to_le_bytes());
+                    request_data.extend_from_slice(&(to_read as u8).to_le_bytes());
+                    let mut prefix = [0u8; 5];
+                    prefix.copy_from_slice(&request_data[0..5]);
+                    let pk = Packet::new(MEMORY_PORT, READ_CHANNEL, request_data);
+                    self.uplink.send_async(pk).await?;
+                    in_flight.push_back((next_send_address, prefix, to_read));
+                    next_send_address += to_read;
+                }
 
-            let (chunk_address, prefix, _to_read) = *in_flight.front().expect("non-empty");
-            let pk = self
-                .read_downlink
-                .wait_packet(MEMORY_PORT, READ_CHANNEL, &prefix)
-                .await?;
-            in_flight.pop_front();
+                let (chunk_address, prefix, to_read) = *in_flight.front().expect("non-empty");
+                let pk = self
+                    .read_downlink
+                    .wait_packet(MEMORY_PORT, READ_CHANNEL, &prefix)
+                    .await?;
+                in_flight.pop_front();
 
-            let pk_data = pk.get_data();
-            if pk_data.len() < 6 {
-                return Err(Error::MemoryError("Malformed memory read response".into()));
-            }
-            let read_address = u32::from_le_bytes(pk_data[1..5].try_into().unwrap());
-            let status = pk_data[5];
-            if status != 0 {
-                return Err(Error::MemoryError(format!(
-                    "Memory read returned error status ({}) @ {}", status, chunk_address
-                )));
-            }
-            if read_address != chunk_address as u32 {
-                return Err(Error::MemoryError("Malformed memory read response".into()));
-            }
-            let read_data = &pk_data[6..];
-            let start = chunk_address - address;
-            let end = start + read_data.len();
-            data[start..end].copy_from_slice(read_data);
+                let pk_data = pk.get_data();
+                if pk_data.len() < 6 {
+                    return Err(Error::MemoryError("Malformed memory read response".into()));
+                }
+                let status = pk_data[5];
+                if status != 0 {
+                    return Err(Error::MemoryError(format!(
+                        "Memory read returned error status ({}) @ {}", status, chunk_address
+                    )));
+                }
+                let read_data = &pk_data[6..];
+                if read_data.len() != to_read {
+                    return Err(Error::MemoryError(format!(
+                        "Short memory read response @ {}: expected {} bytes, got {}",
+                        chunk_address, to_read, read_data.len()
+                    )));
+                }
+                let start = chunk_address - address;
+                let end = start + read_data.len();
+                data[start..end].copy_from_slice(read_data);
 
-            if let Some(ref mut callback) = progress_callback {
-                let confirmed_end = in_flight
-                    .front()
-                    .map(|(addr, _, _)| *addr)
-                    .unwrap_or(next_send_address);
-                callback(confirmed_end - address, length);
+                if let Some(ref mut callback) = progress_callback {
+                    let confirmed_end = in_flight
+                        .front()
+                        .map(|(addr, _, _)| *addr)
+                        .unwrap_or(next_send_address);
+                    callback(confirmed_end - address, length);
+                }
             }
+            Ok(())
+        }
+        .await;
+
+        if result.is_err() {
+            let mut pending: VecDeque<[u8; 5]> =
+                in_flight.iter().map(|(_, prefix, _)| *prefix).collect();
+            drain_pending(&self.read_downlink, READ_CHANNEL, &mut pending).await;
         }
 
-        Ok(data)
+        result.map(|_| data)
     }
 
     pub(crate) async fn write<F>(&self, address: usize, data: &[u8], mut progress_callback: Option<F>) -> Result<()>
@@ -115,63 +154,72 @@ impl MemoryBackend {
     {
         // Responses arrive in send order (single firmware mem task), so we
         // can match by front-of-queue prefix.
-        const PIPELINE_DEPTH: usize = 16;
-
         let length = data.len();
         let end_address = address + length;
         let mut next_send_address = address;
 
-        let mut in_flight: std::collections::VecDeque<(usize, [u8; 5])> =
-            std::collections::VecDeque::with_capacity(PIPELINE_DEPTH);
+        let mut in_flight: VecDeque<(usize, [u8; 5])> =
+            VecDeque::with_capacity(PIPELINE_DEPTH);
 
-        while next_send_address < end_address || !in_flight.is_empty() {
-            while in_flight.len() < PIPELINE_DEPTH && next_send_address < end_address {
-                let to_write = std::cmp::min(
-                    MEM_MAX_REQUEST_SIZE,
-                    end_address - next_send_address,
-                );
-                let start = next_send_address - address;
-                let end = start + to_write;
-                let mut request_data = Vec::new();
-                request_data.extend_from_slice(&self.memory_id.to_le_bytes());
-                request_data.extend_from_slice(&(next_send_address as u32).to_le_bytes());
-                request_data.extend_from_slice(&data[start..end]);
-                let mut prefix = [0u8; 5];
-                prefix.copy_from_slice(&request_data[0..5]);
-                let pk = Packet::new(MEMORY_PORT, WRITE_CHANNEL, request_data);
-                self.uplink.send_async(pk).await?;
-                in_flight.push_back((next_send_address, prefix));
-                next_send_address += to_write;
-            }
+        let result: Result<()> = async {
+            while next_send_address < end_address || !in_flight.is_empty() {
+                while in_flight.len() < PIPELINE_DEPTH && next_send_address < end_address {
+                    let to_write = std::cmp::min(
+                        MEM_MAX_REQUEST_SIZE,
+                        end_address - next_send_address,
+                    );
+                    let start = next_send_address - address;
+                    let end = start + to_write;
+                    let mut request_data = Vec::new();
+                    request_data.extend_from_slice(&self.memory_id.to_le_bytes());
+                    request_data.extend_from_slice(&(next_send_address as u32).to_le_bytes());
+                    request_data.extend_from_slice(&data[start..end]);
+                    let mut prefix = [0u8; 5];
+                    prefix.copy_from_slice(&request_data[0..5]);
+                    let pk = Packet::new(MEMORY_PORT, WRITE_CHANNEL, request_data);
+                    self.uplink.send_async(pk).await?;
+                    in_flight.push_back((next_send_address, prefix));
+                    next_send_address += to_write;
+                }
 
-            let (chunk_address, prefix) = *in_flight.front().expect("non-empty by loop guard");
-            let pk = self
-                .write_downlink
-                .wait_packet(MEMORY_PORT, WRITE_CHANNEL, &prefix)
-                .await?;
-            in_flight.pop_front();
+                let (chunk_address, prefix) = *in_flight.front().expect("non-empty by loop guard");
+                let pk = self
+                    .write_downlink
+                    .wait_packet(MEMORY_PORT, WRITE_CHANNEL, &prefix)
+                    .await?;
+                in_flight.pop_front();
 
-            let pk_data = pk.get_data();
-            if pk_data.len() < 6 {
-                return Err(Error::MemoryError("Malformed memory write response".into()));
-            }
-            let status = pk_data[5];
-            if status != 0 {
-                return Err(Error::MemoryError(format!(
-                    "Memory write returned error status ({}) @ {}",
-                    status, chunk_address
-                )));
-            }
+                let pk_data = pk.get_data();
+                if pk_data.len() < 6 {
+                    return Err(Error::MemoryError("Malformed memory write response".into()));
+                }
+                let status = pk_data[5];
+                if status != 0 {
+                    return Err(Error::MemoryError(format!(
+                        "Memory write returned error status ({}) @ {}",
+                        status, chunk_address
+                    )));
+                }
 
-            if let Some(ref mut callback) = progress_callback {
-                let confirmed_end = in_flight
-                    .front()
-                    .map(|(addr, _)| *addr)
-                    .unwrap_or(next_send_address);
-                callback(confirmed_end - address, length);
+                if let Some(ref mut callback) = progress_callback {
+                    let confirmed_end = in_flight
+                        .front()
+                        .map(|(addr, _)| *addr)
+                        .unwrap_or(next_send_address);
+                    callback(confirmed_end - address, length);
+                }
             }
+            Ok(())
         }
-        Ok(())
+        .await;
+
+        if result.is_err() {
+            let mut pending: VecDeque<[u8; 5]> =
+                in_flight.iter().map(|(_, prefix)| *prefix).collect();
+            drain_pending(&self.write_downlink, WRITE_CHANNEL, &mut pending).await;
+        }
+
+        result
     }
 }
 

--- a/src/subsystems/memory/memory_types.rs
+++ b/src/subsystems/memory/memory_types.rs
@@ -91,7 +91,7 @@ impl MemoryBackend {
             let read_data = &pk_data[6..];
             if read_data.len() != to_read {
                 return Err(Error::MemoryError(format!(
-                    "Short memory read response @ {}: expected {} bytes, got {}",
+                    "Unexpected memory read response length @ {}: expected {} bytes, got {}",
                     chunk_address, to_read, read_data.len()
                 )));
             }


### PR DESCRIPTION
## Summary

`MemoryBackend::read` and `write` were strictly sequential — send a chunk, await its response, then send the next. Every chunk paid a full USB / radio round-trip, which dominated throughput for any non-trivial memory op (892 KB deck firmware ≈ 38000 round-trips).

This PR pipelines both: keep up to **16** requests in flight, match each response against the front-of-queue request prefix. Transport-agnostic, so radio benefits too.

## Effect

Measured on `cfcli mem read MemoryTester -n 4096`:

| transport | sequential | pipelined |
|---|---:|---:|
| USB   | ~10 KB/s | **~170 KB/s** (~17×) |
| radio |  ~8 KB/s |  **~24 KB/s**  (~3×) |

Bigger relative win on USB because USB's per-RTT overhead is smaller relative to per-packet processing — pipelining hides more of it. Radio is still bounded by the radio MAC's ~768 pkt/s steady state but pipelining cuts the per-chunk wait at the host.

## Notes

- The `wait_packet` matching strategy already requires per-chunk prefixes that the firmware echoes — we just keep a `VecDeque` of `(addr, prefix)` pairs and match the front against each incoming response. The firmware's memory task is single-threaded and processes packets in FIFO order, so responses arrive in the same order as the requests. The prefix is the 5-byte `[memory_id, address]`, so address/order matching is handled by `wait_packet` itself.
- Read responses are validated: a non-zero status or an unexpected payload length (`Unexpected memory read response length`) errors out instead of silently misplacing data.
- Error handling with requests in flight: a protocol error (malformed / bad-status / wrong-length response) drains the still in-flight responses before returning, so leftover packets don't desync a subsequent read/write on the same channel. Transport errors (send/receive) propagate as-is without draining — they're almost certainly a disconnect, after which no further packets arrive.
- Progress callback fires per-confirmation (i.e. when a response is matched), reporting the byte offset of the next still-in-flight chunk — feels smooth in `cfcli`'s deck-flash progress bar.
- API unchanged — only `pub(crate)` internals touched. `MemoryBackend::read` / `write` signatures are identical.

## Test plan

- [x] `cfcli mem read MemoryTester -n 4096` (USB): ~170 KB/s.
- [x] `cfcli mem read MemoryTester -n 4096` (radio): ~24 KB/s.
- [x] `cfcli bootload flash --bin bcCam:qcc=...`: completes successfully (it consumes the pipelined `write`).
- [x] No regression in `cfcli test link-perf` (independent code path).
