### PR TITLE
Re-export crazyflie-link and add packet_capture passthrough feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,12 @@ exclude = [
     ".github/*"
 ]
 
+[features]
+# Enable CRTP packet capture in the link (Unix only), see crazyflie_link::capture
+packet_capture = ["crazyflie-link/packet_capture"]
+
 [dependencies]
-crazyflie-link = "0.5.0"
+crazyflie-link = "0.5.1"
 futures-util = "0.3.31"
 futures = "0.3.31"
 async-stream = "0.3.6"

--- a/examples/appchannel.rs
+++ b/examples/appchannel.rs
@@ -19,7 +19,7 @@ use futures::{SinkExt, StreamExt};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new();
+    let link_context = crazyflie_lib::crazyflie_link::LinkContext::new();
 
     // Scan for Crazyflies on the default address
     println!("Scanning for Crazyflie.");

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
 // Example scans for Crazyflies, connect the first one and print the log and param variables TOC.
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new();
+    let link_context = crazyflie_lib::crazyflie_link::LinkContext::new();
 
     // Scan for Crazyflies on the default address
     let found = link_context.scan([0xE7; 5]).await?;

--- a/examples/commander_hover.rs
+++ b/examples/commander_hover.rs
@@ -1,4 +1,4 @@
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 use crazyflie_lib::Crazyflie;
 use tokio::time::{sleep, Duration};
 

--- a/examples/commander_position.rs
+++ b/examples/commander_position.rs
@@ -1,4 +1,4 @@
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 use crazyflie_lib::Crazyflie;
 use tokio::time::{sleep, Duration};
 

--- a/examples/console.rs
+++ b/examples/console.rs
@@ -4,7 +4,7 @@ use futures::StreamExt;
 // Example scans for Crazyflies, connect the first one and print the console message line by line.
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new();
+    let link_context = crazyflie_lib::crazyflie_link::LinkContext::new();
 
     // Scan for Crazyflies on the default address
     let found = link_context.scan([0xE7; 5]).await?;

--- a/examples/display_eeprom.rs
+++ b/examples/display_eeprom.rs
@@ -5,7 +5,7 @@ const URI: &str = "radio://0/80/2M/E7E7E7E7E7";
 // Example that displays the EEPROM config memory contents
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new();
+    let link_context = crazyflie_lib::crazyflie_link::LinkContext::new();
     let cf = crazyflie_lib::Crazyflie::connect_from_uri(&link_context, URI, crazyflie_lib::NoTocCache).await?;
 
     let memories = cf.memory.get_memories(Some(MemoryType::EEPROMConfig));

--- a/examples/display_loco.rs
+++ b/examples/display_loco.rs
@@ -5,7 +5,7 @@ const URI: &str = "radio://0/80/2M/E7E7E7E7E7";
 // Example that reads and displays Loco Positioning System anchor data
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new();
+    let link_context = crazyflie_lib::crazyflie_link::LinkContext::new();
     let cf = crazyflie_lib::Crazyflie::connect_from_uri(&link_context, URI, crazyflie_lib::NoTocCache).await?;
 
     let memories = cf.memory.get_memories(Some(MemoryType::Loco2));

--- a/examples/emergency_stop.rs
+++ b/examples/emergency_stop.rs
@@ -1,6 +1,6 @@
 /// Example demonstrating emergency stop
 use crazyflie_lib::Crazyflie;
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 

--- a/examples/emergency_watchdog.rs
+++ b/examples/emergency_watchdog.rs
@@ -1,6 +1,6 @@
 /// Example demonstrating emergency stop watchdog failsafe behavior
 use crazyflie_lib::Crazyflie;
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 

--- a/examples/external_position.rs
+++ b/examples/external_position.rs
@@ -1,5 +1,5 @@
 use crazyflie_lib::Crazyflie;
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 use std::convert::TryInto;
 use tokio::time::{sleep, Duration};
 

--- a/examples/high_level_commander.rs
+++ b/examples/high_level_commander.rs
@@ -13,7 +13,7 @@
 //! Note: High-level commander methods return immediately after sending the command,
 //! so manual sleeps are needed to wait for each movement to complete.
 
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 use crazyflie_lib::Crazyflie;
 use std::f32::consts::PI;
 use tokio::time::{sleep, Duration};

--- a/examples/led_ring.rs
+++ b/examples/led_ring.rs
@@ -5,7 +5,7 @@ const URI: &str = "radio://0/80/2M/E7E7E7E7E7";
 // Example that cycles through colors on the Crazyflie LED ring
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new();
+    let link_context = crazyflie_lib::crazyflie_link::LinkContext::new();
     let cf = crazyflie_lib::Crazyflie::connect_from_uri(&link_context, URI, crazyflie_lib::NoTocCache).await?;
 
     // Switch to the virtual memory effect so the LED ring reads from LED driver memory

--- a/examples/lighthouse_angles.rs
+++ b/examples/lighthouse_angles.rs
@@ -11,7 +11,7 @@
 /// - Base station calibration data already received by the Crazyflie
 
 use crazyflie_lib::Crazyflie;
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 use futures::StreamExt;
 use std::collections::HashSet;
 use std::time::{Duration, Instant};

--- a/examples/lighthouse_persist.rs
+++ b/examples/lighthouse_persist.rs
@@ -16,7 +16,7 @@
 /// - Geometry/calibration data already in RAM
 
 use crazyflie_lib::Crazyflie;
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/link_service.rs
+++ b/examples/link_service.rs
@@ -6,7 +6,7 @@ use tokio::time::Duration;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new();
+    let link_context = crazyflie_lib::crazyflie_link::LinkContext::new();
 
     let uri = "radio://0/80/2M/E7E7E7E7E7";
     println!("Connecting to {} ...", uri);

--- a/examples/list_logs.rs
+++ b/examples/list_logs.rs
@@ -3,7 +3,7 @@ const URI: &str = "radio://0/60/2M/E7E7E7E7E7";
 // Example that prints a list of the log variables
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new();
+    let link_context = crazyflie_lib::crazyflie_link::LinkContext::new();
     let cf =
         crazyflie_lib::Crazyflie::connect_from_uri(&link_context, URI, crazyflie_lib::NoTocCache)
             .await?;

--- a/examples/list_memories.rs
+++ b/examples/list_memories.rs
@@ -3,7 +3,7 @@ const URI: &str = "radio://0/80/2M/E7E7E7E7E7";
 // Example that prints a list of the memories
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new();
+    let link_context = crazyflie_lib::crazyflie_link::LinkContext::new();
     let cf = crazyflie_lib::Crazyflie::connect_from_uri(&link_context, URI, crazyflie_lib::NoTocCache).await?;
 
     println!("{: <2} | {: <20} | {: <6}", "ID", "Name", "Size");

--- a/examples/list_params.rs
+++ b/examples/list_params.rs
@@ -3,7 +3,7 @@ const URI: &str = "radio://0/60/2M/E7E7E7E7E7";
 // Example that prints a list of the param variables
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new();
+    let link_context = crazyflie_lib::crazyflie_link::LinkContext::new();
     let cf =
         crazyflie_lib::Crazyflie::connect_from_uri(&link_context, URI, crazyflie_lib::NoTocCache)
             .await?;

--- a/examples/motor_ramp.rs
+++ b/examples/motor_ramp.rs
@@ -1,6 +1,6 @@
 /// Simple example that ramps the motor thrust and then stops them
 use crazyflie_lib::Crazyflie;
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 use tokio::time::{Duration, sleep};
 
 #[tokio::main]

--- a/examples/persistent.rs
+++ b/examples/persistent.rs
@@ -1,6 +1,6 @@
 /// Persistent parameters example
 use crazyflie_lib::{Crazyflie, NoTocCache};
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/read_ow.rs
+++ b/examples/read_ow.rs
@@ -5,7 +5,7 @@ const URI: &str = "radio://0/80/2M/E7E7E7E7E7";
 // Example that prints the raw content of the 1-wire
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new();
+    let link_context = crazyflie_lib::crazyflie_link::LinkContext::new();
     let cf = crazyflie_lib::Crazyflie::connect_from_uri(&link_context, URI, crazyflie_lib::NoTocCache).await?;
 
     let memories = cf.memory.get_memories(Some(MemoryType::OneWire));

--- a/examples/reading_supervisor.rs
+++ b/examples/reading_supervisor.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 use tokio::time::sleep;
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 use crazyflie_lib::Crazyflie;
 
 // Example demonstrating how to read the Crazyflie's state through the supervisor.

--- a/examples/test_disconnect.rs
+++ b/examples/test_disconnect.rs
@@ -1,5 +1,5 @@
 use crazyflie_lib::Crazyflie;
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 

--- a/examples/test_logs.rs
+++ b/examples/test_logs.rs
@@ -1,5 +1,5 @@
 use crazyflie_lib::{subsystems::log::LogPeriod, Crazyflie};
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 use std::convert::TryInto;
 use tokio::time::{Duration, sleep};
 

--- a/examples/test_params.rs
+++ b/examples/test_params.rs
@@ -1,5 +1,5 @@
 use crazyflie_lib::Crazyflie;
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 use futures::StreamExt;
 
 #[tokio::main]

--- a/examples/test_toc_cache.rs
+++ b/examples/test_toc_cache.rs
@@ -1,7 +1,7 @@
 /// Example demonstrating a simple in-memory TOC cache implementation
 /// and measuring connection times with and without TOC caching.
 use crazyflie_lib::{Crazyflie, TocCache};
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 use std::{collections::HashMap, sync::Arc, sync::RwLock};
 use tokio::time::{sleep, Duration};
 

--- a/examples/trajectory.rs
+++ b/examples/trajectory.rs
@@ -9,7 +9,7 @@
 /// library doesn't currently have access to. Users must manually sleep for the expected duration.
 
 
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 use crazyflie_lib::Crazyflie;
 use tokio::time::{sleep, Duration};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //! For example:
 //! ``` no_run
 //! # async fn test() -> Result<(), Box<dyn std::error::Error>> {
-//! let link_context = crazyflie_link::LinkContext::new();
+//! let link_context = crazyflie_lib::crazyflie_link::LinkContext::new();
 //!
 //! // Scan for Crazyflies on the default address
 //! let found = link_context.scan([0xE7; 5]).await?;
@@ -73,6 +73,25 @@
 //! # }
 //! ```
 //!
+//! ## Relation to the crazyflie-link and crazyradio crates
+//!
+//! Types from the [crazyflie-link] crate appear in this crate's public API (for example
+//! [`crazyflie_link::LinkContext`] and [`crazyflie_link::Connection`] in
+//! [`Crazyflie::connect_from_uri()`] and [`Crazyflie::connect_from_link()`]), which makes
+//! crazyflie-link a *public dependency*: code using this crate needs to name its types. To
+//! avoid a separate, possibly version-mismatched crazyflie-link dependency downstream, the
+//! crate is re-exported at [`crazyflie_link`] — use it through this path instead of adding
+//! a direct dependency. The crazyradio crate is reachable the same way, as
+//! `crazyflie_lib::crazyflie_link::crazyradio`.
+//!
+//! This is a supported part of the API: the re-exported crates only move to
+//! semver-incompatible versions in a semver-incompatible release of this crate.
+//!
+//! ## Cargo features
+//!
+//! - **packet_capture** - Enable CRTP packet capture in the link (Unix only). Forwards to
+//!   the crazyflie-link feature of the same name, see `crazyflie_link::capture`.
+//!
 //! [crazyflie-link]: https://crates.io/crates/crazyflie-link
 
 #![warn(missing_docs)]
@@ -83,6 +102,18 @@ mod error;
 mod value;
 
 pub mod subsystems;
+
+/// Re-export of the exact [`crazyflie_link`] crate version this crate was built against.
+///
+/// crazyflie-link is a public dependency of this crate (its types appear in our API,
+/// e.g. [`crazyflie_link::LinkContext`]). Use this re-export instead of a direct
+/// crazyflie-link dependency to guarantee a single, version-matched copy in your build;
+/// the crazyradio crate is likewise available as
+/// `crazyflie_lib::crazyflie_link::crazyradio`.
+///
+/// Supported API: the re-exported crates only change incompatibly in a
+/// semver-incompatible release of this crate.
+pub use crazyflie_link;
 
 pub use crate::crazyflie::Crazyflie;
 pub use crate::error::{Error, Result};

--- a/src/subsystems/high_level_commander.rs
+++ b/src/subsystems/high_level_commander.rs
@@ -61,7 +61,7 @@ pub const TRAJECTORY_TYPE_POLY4D_COMPRESSED: u8 = 1;
 ///
 /// # Safe usage pattern
 /// ```no_run
-/// # use crazyflie_link::LinkContext;
+/// # use crazyflie_lib::crazyflie_link::LinkContext;
 /// # use crazyflie_lib::Crazyflie;
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// # let context = LinkContext::new();

--- a/src/subsystems/log.rs
+++ b/src/subsystems/log.rs
@@ -8,7 +8,7 @@
 //!
 //! ```no_run
 //! # use crazyflie_lib::{Crazyflie, Value, Error, subsystems::log::LogPeriod};
-//! # use crazyflie_link::LinkContext;
+//! # use crazyflie_lib::crazyflie_link::LinkContext;
 //! # async fn example() -> Result<(), Error> {
 //! # let context = LinkContext::new();
 //! # let cf = Crazyflie::connect_from_uri(

--- a/src/subsystems/memory/mod.rs
+++ b/src/subsystems/memory/mod.rs
@@ -179,7 +179,7 @@ impl Memory {
     /// ```no_run
     /// use crazyflie_lib::subsystems::memory::MemoryType;
     /// use crazyflie_lib::{Crazyflie, Value, Error};
-    /// use crazyflie_link::LinkContext;
+    /// use crazyflie_lib::crazyflie_link::LinkContext;
     /// async fn example() -> Result<(), Error> {
     ///   let context = LinkContext::new();
     ///   let cf = Crazyflie::connect_from_uri(
@@ -196,7 +196,7 @@ impl Memory {
     /// ```no_run
     /// use crazyflie_lib::subsystems::memory::MemoryType;
     /// use crazyflie_lib::{Crazyflie, Value, Error};
-    /// use crazyflie_link::LinkContext;
+    /// use crazyflie_lib::crazyflie_link::LinkContext;
     /// async fn example() -> Result<(), Error> {
     ///   let context = LinkContext::new();
     ///   let cf = Crazyflie::connect_from_uri(

--- a/src/subsystems/param.rs
+++ b/src/subsystems/param.rs
@@ -301,7 +301,7 @@ impl Param {
     ///
     /// ```no_run
     /// # use crazyflie_lib::{Crazyflie, Value, Error};
-    /// # use crazyflie_link::LinkContext;
+    /// # use crazyflie_lib::crazyflie_link::LinkContext;
     /// # async fn example() -> Result<(), Error> {
     /// # let context = LinkContext::new();
     /// # let cf = Crazyflie::connect_from_uri(
@@ -380,7 +380,7 @@ impl Param {
     /// the return parameter. For example to get a u16 param:
     /// ```no_run
     /// # use crazyflie_lib::{Crazyflie, Value, Error};
-    /// # use crazyflie_link::LinkContext;
+    /// # use crazyflie_lib::crazyflie_link::LinkContext;
     /// # async fn example() -> Result<(), Error> {
     /// # let context = LinkContext::new();
     /// # let cf = Crazyflie::connect_from_uri(


### PR DESCRIPTION
crazyflie-link types (LinkContext, Connection, Packet, Error) are part of this crate's public API, so clients had to add their own crazyflie-link and crazyradio dependencies and keep their versions manually in sync with ours - a mismatch produces two copies of the crates and confusing "expected LinkContext, found LinkContext" type errors.

Re-export the crate so clients can reach the exact link (and, through link's own re-export, crazyradio) that this crate was compiled against via crazyflie_lib::crazyflie_link, and drop their direct dependencies.

Since features can only be enabled on direct dependencies, also add a packet_capture passthrough feature (off by default, Unix only) so clients that use CRTP packet capture can migrate fully.

Document the re-export as supported API in the crate docs and switch all doc examples to the re-exported path, so they compile with only crazyflie-lib as a dependency.

Requires crazyflie-link 0.5.1, the first version with the crazyradio re-export. Verified against cfcli and cflib2: both compile unchanged with the new versions, and with all direct link/radio dependencies removed when using the re-exported paths.