### PR TITLE
Improves trajectory and memory examples and docs

### DIFF
--- a/examples/trajectory.rs
+++ b/examples/trajectory.rs
@@ -1,24 +1,13 @@
-/// Commander example that demonstrates starting a predefined trajectory.
-///
-/// NOTE: This assumes a trajectory has already been uploaded to the Crazyflie's
-/// trajectory memory at `MEMORY_OFFSET` with `PIECE_COUNT` pieces.
-/// The Rust memory upload subsystem is not implemented yet.
-///
-/// Unlike other high-level commander methods, `start_trajectory` is non-blocking
-/// because the trajectory duration is determined by the uploaded data, which the
-/// library doesn't currently have access to. Users must manually sleep for the expected duration.
-
-
-use crazyflie_lib::crazyflie_link::LinkContext;
+//! Example: upload and run a predefined trajectory via the high-level commander.
 use crazyflie_lib::Crazyflie;
-use tokio::time::{sleep, Duration};
-
+use crazyflie_lib::subsystems::memory::{MemoryType, Poly, Poly4D, TrajectoryMemory};
+use crazyflie_link::LinkContext;
+use tokio::time::{Duration, sleep};
 
 const TRAJECTORY_ID: u8 = 1;
 const MEMORY_OFFSET: u32 = 0;
-const PIECE_COUNT: u8 = 10;        // adjust to your uploaded trajectory
-const TIME_SCALE: f32 = 1.0;       // 1.0 = original timing
-const EXPECTED_DURATION_S: u64 = 6; // rough duration of the uploaded trajectory
+const TIME_SCALE: f32 = 1.0;        // 1.0 = original timing
+const EXPECTED_DURATION_S: u64 = 3; // sum of segment durations (3 × 1.0s)
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -26,40 +15,77 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let crazyflie = Crazyflie::connect_from_uri(
         &context,
         "radio://0/80/2M/E7E7E7E7E7",
-        crazyflie_lib::NoTocCache
+        crazyflie_lib::NoTocCache,
     )
     .await?;
 
-    // Bind trajectory ID to memory (assumes data is already uploaded there).
+    // Flies a triangle at 0.5 m: (0,0) -> (1,0) -> (0.5,1) -> (0,0)
+    let z = Poly::from_slice(&[0.5]);
+    let yaw = Poly::from_slice(&[]);
+
+    let x = Poly::from_slice(&[0.0, 1.0]);
+    let y = Poly::from_slice(&[]);
+    let segment1 = Poly4D::new(1.0, x, y, z.clone(), yaw.clone());
+
+    let x = Poly::from_slice(&[1.0, -0.5]);
+    let y = Poly::from_slice(&[0.0, 1.0]);
+    let segment2 = Poly4D::new(1.0, x, y, z.clone(), yaw.clone());
+
+    let x = Poly::from_slice(&[0.5, -0.5]);
+    let y = Poly::from_slice(&[1.0, -1.0]);
+    let segment3 = Poly4D::new(1.0, x, y, z, yaw);
+
+    let segments = vec![segment1, segment2, segment3];
+
+    // Open the trajectory memory and upload the segments.
+    let memory_device = crazyflie
+        .memory
+        .get_memories(Some(MemoryType::Trajectory))
+        .pop()
+        .cloned()
+        .ok_or("No trajectory memory device found.")?;
+
+    let trajectory_memory: TrajectoryMemory =
+        crazyflie
+            .memory
+            .open_memory(memory_device)
+            .await
+            .ok_or("Trajectory memory not found.")??;
+
+    println!("Uploading trajectory...");
+    trajectory_memory
+        .write_uncompressed(&segments, MEMORY_OFFSET as usize)
+        .await?;
+
+    // Register the uploaded trajectory under an ID the high-level commander can run.
     println!("Defining trajectory...");
-    if let Err(e) = crazyflie
+    crazyflie
         .high_level_commander
-        .define_trajectory(TRAJECTORY_ID, MEMORY_OFFSET, PIECE_COUNT, None)
-        .await
-    {
-        eprintln!("Define trajectory failed: {e}");
-    }
-    sleep(Duration::from_secs(1)).await;
+        .define_trajectory(TRAJECTORY_ID, MEMORY_OFFSET, segments.len() as u8, None)
+        .await?;
 
     println!("Taking off...");
-    crazyflie.high_level_commander.take_off(0.8, None, 2.0, None).await?;
+    crazyflie
+        .high_level_commander
+        .take_off(0.5, None, 2.0, None)
+        .await?;
+    sleep(Duration::from_millis(2100)).await; // wait out the 2.0s take-off
 
     println!("Starting trajectory...");
-    if let Err(e) = crazyflie
+    crazyflie
         .high_level_commander
         .start_trajectory(TRAJECTORY_ID, TIME_SCALE, true, false, false, None)
-        .await
-    {
-        eprintln!("Start trajectory failed: {e}");
-    }
+        .await?;
     sleep(Duration::from_secs(EXPECTED_DURATION_S)).await;
 
     println!("Landing...");
-    if let Err(e) = crazyflie.high_level_commander.land(0.0, None, 2.0, None).await {
-        eprintln!("Land command failed: {e}");
-    }
+    crazyflie
+        .high_level_commander
+        .land(0.0, None, 2.0, None)
+        .await?;
+    sleep(Duration::from_secs(2)).await; // wait out the 2.0s land
 
-    crazyflie.high_level_commander.stop(None).await?;
+    crazyflie.high_level_commander.stop(None).await?; // motors off
     println!("Done");
     Ok(())
 }

--- a/examples/trajectory.rs
+++ b/examples/trajectory.rs
@@ -1,7 +1,7 @@
 //! Example: upload and run a predefined trajectory via the high-level commander.
 use crazyflie_lib::Crazyflie;
 use crazyflie_lib::subsystems::memory::{MemoryType, Poly, Poly4D, TrajectoryMemory};
-use crazyflie_link::LinkContext;
+use crazyflie_lib::crazyflie_link::LinkContext;
 use tokio::time::{Duration, sleep};
 
 const TRAJECTORY_ID: u8 = 1;

--- a/src/subsystems/high_level_commander.rs
+++ b/src/subsystems/high_level_commander.rs
@@ -345,7 +345,7 @@ impl HighLevelCommander {
     /// * `trajectory_id` - Identifier used to reference this trajectory later.
     /// * `memory_offset` - Byte offset into trajectory memory where the data begins.
     /// * `piece_count` - Number of segments (pieces) in the trajectory.
-    /// * `trajectory_type` - Type of the trajectory data (e.g. Poly4D).
+    /// * `trajectory_type` - Type of the trajectory data (e.g. [`TRAJECTORY_TYPE_POLY4D`] or [`TRAJECTORY_TYPE_POLY4D_COMPRESSED`]).
     ///
     /// # Errors
     /// Returns [`Error::Disconnected`] if the command cannot be sent.

--- a/src/subsystems/memory/mod.rs
+++ b/src/subsystems/memory/mod.rs
@@ -223,7 +223,7 @@ impl Memory {
     /// # Arguments
     /// * `memory` - The MemoryDevice struct representing the memory to get
     /// # Returns
-    /// An Option containing a reference to the MemoryDevice struct if found, or None if not found
+    /// An Option containing a Result with the opened memory on success, or None if not found
     pub async fn open_memory<T: FromMemoryBackend>(&self, memory: MemoryDevice) -> Option<Result<T>> {
       let backend = self.backends.get(memory.memory_id as usize)?.lock().await.take()?;
       Some(T::from_memory_backend(backend).await)

--- a/src/subsystems/memory/trajectory.rs
+++ b/src/subsystems/memory/trajectory.rs
@@ -204,8 +204,8 @@ enum ElementType {
     Constant = 0,
     /// Linear (1 coefficient)
     Linear = 1,
-    /// Quadratic (3 coefficients)
-    Quadratic = 2,
+    /// Cubic (3 coefficients)
+    Cubic = 2,
     /// Full (7 coefficients)
     Full = 3,
 }
@@ -215,7 +215,7 @@ impl ElementType {
         match len {
             0 => Some(ElementType::Constant),
             1 => Some(ElementType::Linear),
-            3 => Some(ElementType::Quadratic),
+            3 => Some(ElementType::Cubic),
             7 => Some(ElementType::Full),
             _ => None,
         }

--- a/src/subsystems/memory/trajectory.rs
+++ b/src/subsystems/memory/trajectory.rs
@@ -127,7 +127,7 @@ impl Poly4D {
     ///
     /// # Arguments
     /// * `duration` - Length of the segment in **seconds**
-    /// * `x`, `y`, `z` - Position polynomials, in metres.
+    /// * `x`, `y`, `z` - Position polynomials, in meters.
     /// * `yaw` - Heading polynomial, in radians.
     pub fn new(duration: f32, x: Poly, y: Poly, z: Poly, yaw: Poly) -> Self {
         Self { duration, x, y, z, yaw }
@@ -224,8 +224,8 @@ impl ElementType {
 
 /// A segment in a compressed trajectory
 ///
-/// Compressed segments hold Bézier control points, it does not store the raw coefficients, but
-/// the control points of the Bézier curve.
+/// Compressed segments store the Bézier control points rather than
+/// the polynomial coefficients of the curve.
 /// Segments vectors can be either of constant (0), linear (1), cubic (3), or full (7) length.
 #[derive(Debug, Clone)]
 pub struct CompressedSegment {

--- a/src/subsystems/memory/trajectory.rs
+++ b/src/subsystems/memory/trajectory.rs
@@ -2,8 +2,46 @@
 //!
 //! This module provides types and functionality for defining and uploading
 //! trajectories to the Crazyflie's trajectory memory. Trajectories can be
-//! either uncompressed (using `Poly4D`) or compressed (using `CompressedStart`
-//! and `CompressedSegment`).
+//! either uncompressed (using `Poly4D`) or compressed (using `CompressedStart` and `CompressedSegment`).
+//!
+//! See the Crazyflie firmware documentation on
+//! [trajectory formats](https://www.bitcraze.io/documentation/repository/crazyflie-firmware/master/functional-areas/trajectory_formats/)
+//! for the format details.
+//!
+//! # Example
+//!
+//! Upload a trajectory and run it. Each `Poly4D` segment describes position over its `duration`
+//! (see [`Poly`]).
+//!
+//! ```no_run
+//! # use crazyflie_lib::Crazyflie;
+//! use crazyflie_lib::subsystems::memory::{MemoryType, Poly, Poly4D, TrajectoryMemory};
+//! # async fn run(cf: Crazyflie) -> Result<(), Box<dyn std::error::Error>> {
+//! // One segment: fly 1 m forward in x over 2 s at 0.5 m, no yaw.
+//! let segment = Poly4D::new(
+//!     2.0,
+//!     Poly::from_slice(&[0.0, 0.5]), // x: 0 -> 1
+//!     Poly::from_slice(&[]),         // y: 0
+//!     Poly::from_slice(&[0.5]),      // z: constant 0.5
+//!     Poly::from_slice(&[]),         // yaw: 0
+//! );
+//!
+//! // Open the trajectory memory and upload the segments.
+//! let device = cf
+//!     .memory
+//!     .get_memories(Some(MemoryType::Trajectory))
+//!     .pop()
+//!     .cloned()
+//!     .ok_or("no trajectory memory")?;
+//! let trajectory: TrajectoryMemory =
+//!     cf.memory.open_memory(device).await.ok_or("already open or missing")??;
+//! trajectory.write_uncompressed(&[segment], 0).await?;
+//!
+//! // Register it under an id the high-level commander can run.
+//! cf.high_level_commander.define_trajectory(1, 0, 1, None).await?;
+//! # Ok(())
+//! # }
+//! ```
 
 use crate::{Error, Result, subsystems::memory::{MemoryBackend, memory_types}};
 use memory_types::{FromMemoryBackend, MemoryType};
@@ -86,6 +124,11 @@ pub struct Poly4D {
 
 impl Poly4D {
     /// Create a new Poly4D trajectory segment
+    ///
+    /// # Arguments
+    /// * `duration` - Length of the segment in **seconds**
+    /// * `x`, `y`, `z` - Position polynomials, in metres.
+    /// * `yaw` - Heading polynomial, in radians.
     pub fn new(duration: f32, x: Poly, y: Poly, z: Poly, yaw: Poly) -> Self {
         Self { duration, x, y, z, yaw }
     }
@@ -181,9 +224,9 @@ impl ElementType {
 
 /// A segment in a compressed trajectory
 ///
-/// Compressed segments use variable-length encoding where each axis
-/// can have 0, 1, 3, or 7 coefficients depending on the complexity
-/// of motion along that axis.
+/// Compressed segments hold Bézier control points, it does not store the raw coefficients, but
+/// the control points of the Bézier curve.
+/// Segments vectors can be either of constant (0), linear (1), cubic (3), or full (7) length.
 #[derive(Debug, Clone)]
 pub struct CompressedSegment {
     duration: f32,
@@ -406,5 +449,4 @@ impl TrajectoryMemory {
         self.memory.write(start_addr, &data, Some(progress_callback)).await?;
         Ok(data.len())
     }
-
 }


### PR DESCRIPTION
While working on my project and exploring trajectory upload, I realized that the example for trajectories is not up to date with what the library supports by now.

I tried to change it to a minimal example that actually uploads trajectories. It also fixes waiting on the high-level command, or maybe the API was different back when this was written. 

And I can verify that it flies a triangle correctly for my crazyflie. 

Additionally, I'm suggesting to include a short example in the documentation as well. That would have helped me to get started here. 

In the second commit, I'm also suggesting changing the element type from quadratic to cubic. I think that represents accurately what the [documentation](https://www.bitcraze.io/documentation/repository/crazyflie-firmware/master/functional-areas/trajectory_formats/) states that type is. 
